### PR TITLE
fix(reference): update method specificity for target method to patch

### DIFF
--- a/FieldExpressions/Core/AllowExpressionsInFields.cs
+++ b/FieldExpressions/Core/AllowExpressionsInFields.cs
@@ -20,7 +20,6 @@ namespace FieldExpressions.Core
             Harmony harmony = new Harmony("net.Toxic_Cookie.FieldExpressions");
             harmony.PatchAll();
 
-            evaluator.CultureInfoForNumberParsing = CultureInfo.InvariantCulture;
             evaluator.OptionCaseSensitiveEvaluationActive = false;
             evaluator.OptionInlineNamespacesEvaluationRule = InlineNamespacesEvaluationRule.AllowOnlyInlineNamespacesList;
         }

--- a/FieldExpressions/Core/AllowExpressionsInFields.cs
+++ b/FieldExpressions/Core/AllowExpressionsInFields.cs
@@ -27,7 +27,7 @@ namespace FieldExpressions.Core
 
         public static ExpressionEvaluator evaluator = new ExpressionEvaluator();
 
-        [HarmonyPatch(typeof(PrimitiveMemberEditor), "ParseAndAssign")]
+        [HarmonyPatch(typeof(PrimitiveMemberEditor), "ParseAndAssign", argumentTypes: new Type[] { })]
         class AllowExpressionsInFields
         {
             static bool Prefix(PrimitiveMemberEditor __instance, ref SyncRef<TextEditor> ____textEditor, ref FieldDrive<string> ____textDrive)

--- a/FieldExpressions/FieldExpressions.csproj
+++ b/FieldExpressions/FieldExpressions.csproj
@@ -4,26 +4,38 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <ResonitePath>$(MSBuildThisFileDirectory)Resonite</ResonitePath>
+    <ResonitePath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
+    <ResonitePath Condition="Exists('D:\Program Files (x86)\Steam\steamapps\common\Resonite\')">D:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
+    <ResonitePath Condition="Exists('C:\SteamLibrary\steamapps\common\Resonite\')">C:\SteamLibrary\steamapps\common\Resonite\</ResonitePath>
+    <ResonitePath Condition="Exists('D:\SteamLibrary\steamapps\common\Resonite\')">D:\SteamLibrary\steamapps\common\Resonite\</ResonitePath>
+    <ResonitePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</ResonitePath>
+    <ResonitePath Condition="Exists('E:\Programs\Steam\steamapps\common\Resonite')">E:\Programs\Steam\steamapps\common\Resonite\</ResonitePath>
+    <CopyToMods Condition="'$(CopyToMods)'==''">true</CopyToMods>
+  </PropertyGroup>
+
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Resonite\rml_mods&quot;" />
+    <Exec Command="copy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ResonitePath)rml_mods&quot;" />
   </Target>
 
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\NeosVR\0Harmony.dll</HintPath>
+      <HintPath>$(ResonitePath)rml_libs\0Harmony.dll</HintPath>
+      <HintPath Condition="Exists('$(ResonitePath)0Harmony.dll')">$(ResonitePath)0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="CodingSeb.ExpressionEvaluator">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Resonite\rml_libs\CodingSeb.ExpressionEvaluator.dll</HintPath>
+      <HintPath>$(ResonitePath)rml_libs\CodingSeb.ExpressionEvaluator.dll</HintPath>
     </Reference>
     <Reference Include="Elements.Core">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Resonite\Resonite_Data\Managed\Elements.Core.dll</HintPath>
+      <HintPath>$(ResonitePath)Resonite_Data\Managed\Elements.Core.dll</HintPath>
     </Reference>
     <Reference Include="FrooxEngine">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Resonite\Resonite_Data\Managed\FrooxEngine.dll</HintPath>
+      <HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="ResoniteModLoader">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Resonite\Libraries\ResoniteModLoader.dll</HintPath>
+      <HintPath>$(ResonitePath)Libraries\ResoniteModLoader.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FieldExpressions
 
-A [NeosModLoader](https://github.com/zkxs/NeosModLoader) mod for [Neos VR](https://neos.com/) that allows you to use [CodingSeb's Expression Evaluator](https://github.com/codingseb/ExpressionEvaluator/wiki/Getting-Started) in inspector fields.
+A [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoader) mod for [Resonite](https://resonite.com/) that allows you to use [CodingSeb's Expression Evaluator](https://github.com/codingseb/ExpressionEvaluator/wiki/Getting-Started) in inspector fields.
 
 ## Installation
-1. Install [NeosModLoader](https://github.com/zkxs/NeosModLoader).
-2. Place [FieldExpressions.dll](https://github.com/Toxic-Cookie/FieldExpressions/releases) into your `nml_mods` folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\NeosVR\nml_mods` for a default install. You can create it if it's missing, or if you launch the game once with NeosModLoader installed it will create the folder for you.
-3. Start the game. If you want to verify that the mod is working you can check your Neos logs.
+1. Install [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoader).
+2. Place [FieldExpressions.dll](https://github.com/Toxic-Cookie/FieldExpressions/releases) into your `rml_mods` folder. This folder should be located in the same folder as Resonite. For a default installation on Windows, the typical location is `C:\Program Files (x86)\Steam\steamapps\common\Resonite\rml_mods`. You can create it if it's missing, or if you launch the game once with ResoniteModLoader installed it will create the folder for you.
+3. Start the game. If you want to verify that the mod is working, you can check your Resonite logs.


### PR DESCRIPTION
This PR aims to correct the current exception that is being thrown due to an update to the `PrimitiveMemberEditor` class's `ParseAndAssign` method in `FrooxEngine`. This method now contains another definition where an argument of string can be passed in. Due to this, Harmony patching cannot determine the exact method to patch.

In addition, this fix also includes another bug fix where setting the Culture for ExpressionEvaluator causes an exception to be thrown. This exception is due to ExpressionEvaluator setting a property on Culture that is marked as Readonly. Since ExpressionEvaluator already defaults the Culture to InvariantCulture, there is no need to set it again; removing this set also fixes that exception.

Fixes #2.